### PR TITLE
Update common.py

### DIFF
--- a/bps-common/bps/common/io/common.py
+++ b/bps-common/bps/common/io/common.py
@@ -359,6 +359,7 @@ class LayerType(Enum):
     HEIGHT_M = "Height [m]"
     INCIDENCE_ANGLE_DEG = "Incidence angle [deg]"
     ELEVATION_ANGLE_DEG = "Elevation angle [deg]"
+    TERRAIN_SLOPE = "Terrain slope [deg]"
     RANGE_TERRAIN_SLOPE_DEG = "Range terrain slope [deg]"
     AZIMUTH_TERRAIN_SLOPE_DEG = "Azimuth terrain slope [deg]"
     FNF = "FNF"


### PR DESCRIPTION
~/anaconda3/envs/bps_env/lib/python3.12/site-packages/xsdata/formats/dataclass/parsers/utils.py:130: ConverterWarning: Failed to convert value for `LayerListType.layer`
  `Terrain slope [deg]` is not a valid `LayerType`
  warnings.warn(message, ConverterWarning)
2026-04-10T17:35:25.557000 workstation STA_P 04.40 STA_P [0000208316]: [E] KeyError: 'Terrain slope [deg]'