### PR TITLE
Chore/repository config foundation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,81 @@
+# ------------------------------------------------------------------------------
+# BIOMASS BPS — Code Owners
+# SPDX-FileCopyrightText: 2026 European Space Agency (ESA) - ACRI-ST
+# SPDX-License-Identifier: Apache-2.0
+#
+# Rules:
+#   - Last matching line wins.
+#   - Only users with WRITE access can be code owners.
+#   - Personal repos accept @usernames only (no @org/team syntax).
+#   - Replace handles below with real GitHub usernames before enforcing.
+# ------------------------------------------------------------------------------
+
+# ---- Catch-all: Core Maintainer reviews anything not matched below -----------
+*                                       @matteoaletti
+
+# ---- CI / CD / repo governance -----------------------------------------------
+/.github/                               @yreyricord
+/.pre-commit-config.yaml                @matteoaletti
+/REUSE.toml                             @yreyricord
+/LICENSES/                              @yreyricord
+/pyproject.toml                         @matteoaletti
+/pytest.ini                             @matteoaletti
+/ruff.toml                              @matteoaletti
+/noxfile.py                             @matteoaletti
+/.gitignore                             @matteoaletti
+/.secrets.baseline                      @matteoaletti
+
+# ---- Shared libraries --------------------------------------------------------
+/bps-common/                            @matteoaletti 
+/bps-task-tables/                       @matteoaletti 
+/bps-transcoder/                        @matteoaletti 
+
+# ---- L1 processors (SME review required) ------------------------------------
+/bps-l1_binaries/                       @matteoaletti 
+/bps-l1_core_processor/                 @matteoaletti 
+/bps-l1_framing_processor/              @matteoaletti 
+/bps-l1_pre_processor/                  @matteoaletti 
+/bps-l1_processor/                      @matteoaletti 
+
+# ---- L2 processors (SME review required) ------------------------------------
+/bps-l2a_processor/                     @matteoaletti 
+/bps-l2b_agb_processor/                 @matteoaletti 
+/bps-l2b_fd_processor/                  @matteoaletti 
+/bps-l2b_fh_processor/                  @matteoaletti 
+
+# ---- Stack processors (SME review required) ---------------------------------
+/bps-stack_binaries/                    @matteoaletti 
+/bps-stack_cal_processor/               @matteoaletti 
+/bps-stack_coreg_processor/             @matteoaletti 
+/bps-stack_pre_processor/               @matteoaletti 
+/bps-stack_processor/                   @matteoaletti 
+
+# ---- Container / packaging ---------------------------------------------------
+/bps-dockerfiles/                       @matteoaletti
+
+# ---- Tests -------------------------------------------------------------------
+/test/                                  @matteoaletti
+**/tests/unit/                          @matteoaletti
+**/tests/integration/                   @matteoaletti 
+**/tests/fixtures/                      @matteoaletti 
+# baseline and smoke dirs: SME must review when reference outputs change
+**/tests/baseline/                      @matteoaletti 
+**/tests/smoke/                         @matteoaletti 
+/tests/extended/                        @matteoaletti 
+/tests/heavy/                           @matteoaletti 
+
+# ---- Documentation -----------------------------------------------------------
+/README.md                              @matteoaletti
+/CREDITS.md                             @matteoaletti
+/LICENSE.md                             @yreyricord
+**/docs/                                @yreyricord
+**/docs/science/                        @yreyricord 
+
+# ---- Scripts & schemas -------------------------------------------------------
+/scripts/                               @matteoaletti
+/xsd/                                   @matteoaletti 
+
+# ---- Release gate (ESA approval mandatory) ----------------------------------
+# Any change to VERSION triggers mandatory ESA review on main.
+# This is enforced via "Require review from Code Owners" on the main ruleset.
+/VERSION                                @matteoaletti 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 European Space Agency (ESA) - ACRI-ST
+# SPDX-FileCopyrightText: 2026 European Space Agency (ESA) - ACRI-ST - ARESYS
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
@@ -32,6 +32,11 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    groups:
+    python-minor-and-patch:
+      update-types:
+        - "minor"
+        - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 European Space Agency (ESA) - ACRI-ST
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    target-branch: "develop"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    target-branch: "develop"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,21 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/bps-common"
+      - "/bps-l1_core_processor"
+      - "/bps-l1_framing_processor"
+      - "/bps-l1_pre_processor"
+      - "/bps-l1_processor"
+      - "/bps-l2a_processor"
+      - "/bps-l2b_agb_processor"
+      - "/bps-l2b_fd_processor"
+      - "/bps-l2b_fh_processor"
+      - "/bps-stack_cal_processor"
+      - "/bps-stack_coreg_processor"
+      - "/bps-stack_pre_processor"
+      - "/bps-stack_processor"
+      - "/bps-transcoder"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,10 +33,10 @@ updates:
       - "dependencies"
       - "python"
     groups:
-    python-minor-and-patch:
-      update-types:
-        - "minor"
-        - "patch"
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: 2026 European Space Agency (ESA)
+# SPDX-License-Identifier: Apache-2.0
+#
+# REUSE 3.0 manifest for BIOMASS BPS.
+#
+# Strategy.
+#   Files added from this point on must carry inline SPDX headers
+#   (`SPDX-FileCopyrightText` and `SPDX-License-Identifier`) in their own
+#   source. This manifest covers two categories:
+#     1. Legacy files that pre-date the REUSE work, grouped by category.
+#        A follow-up issue tracks their progressive migration to inline
+#        headers.
+#     2. Files that cannot carry an inline header (binary assets, third
+#        party content with strict format).
+#
+# Spec:  https://reuse.software/spec/
+# Lint:  reuse lint
+
+version = 1
+
+# ─────────────────────────────────────────────────────────────────────
+# Repository-level configuration and metadata
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = [
+  ".gitignore",
+  "**/.gitignore",
+  "**/.dockerignore",
+  ".vscode/**",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 European Space Agency (ESA)"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ─────────────────────────────────────────────────────────────────────
+# Legacy GitLab CI configuration (kept until full migration to GitHub
+# Actions is complete)
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = [
+  ".gitlab-ci.yml",
+  ".gitlab/**",
+  "**/.gitlab-ci.yml",
+  ".conda-packaging-ci.yml",
+  ".docker-ci.yml",
+  ".testplan-ci.yml",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 European Space Agency (ESA)"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ─────────────────────────────────────────────────────────────────────
+# Top-level and per-package READMEs and credits
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = [
+  "README.md",
+  "CREDITS.md",
+  "**/README.md",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 European Space Agency (ESA)"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ─────────────────────────────────────────────────────────────────────
+# Python project metadata, build, and lint configuration
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = [
+  "**/pyproject.toml",
+  "**/noxfile.py",
+  "ruff.toml",
+  "scripts/fawltydeps.toml",
+  "scripts/**/*.toml",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 European Space Agency (ESA)"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ─────────────────────────────────────────────────────────────────────
+# Conda recipes
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = [
+  "**/recipe/meta.yaml",
+  "**/recipe/build.sh",
+  "**/recipe/conda_build_config.yaml",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 European Space Agency (ESA)"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ─────────────────────────────────────────────────────────────────────
+# Docker assets
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = [
+  "**/Dockerfile",
+  "**/Dockerfile-*",
+  "bps-dockerfiles/**/*.sh",
+  "bps-dockerfiles/bundle_resources/**",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 European Space Agency (ESA)"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ─────────────────────────────────────────────────────────────────────
+# Existing test suites and fixtures
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = [
+  "**/test/**",
+  "**/tests/**",
+  "test/integration/**",
+  "test/requirements.txt",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 European Space Agency (ESA)"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ─────────────────────────────────────────────────────────────────────
+# BIOMASS-specific XSD schemas and XML task tables
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = [
+  "xsd/biomass-xsd/**",
+  "xsd/.xsdata.xml",
+  "**/biomass-xsd/**",
+  "bps-task-tables/**/*.xml",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 European Space Agency (ESA)"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ─────────────────────────────────────────────────────────────────────
+# ESA ground-segment generic schemas (ICD)
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = ["xsd/icd-xsd/**"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 European Space Agency (ESA)"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ─────────────────────────────────────────────────────────────────────
+# Reference data bundled with the L1 processor
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = [
+  "bps-l1_processor/bps/l1_processor/resources/bulletinb-*.txt",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "International Earth Rotation and Reference Systems Service (IERS)"
+SPDX-License-Identifier = "CC-BY-4.0"
+
+# ─────────────────────────────────────────────────────────────────────
+# Third-party schemas (OGC and external standards bodies).
+# Licence declared provisionally as CC-BY-4.0 pending confirmation by
+# legal maintainers. To resolve before this manifest is merged.
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = [
+  "**/eop.xsd",
+  "**/sar.xsd",
+  "**/bio-l1-vrt.xsd",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "Open Geospatial Consortium (OGC) and contributors"
+SPDX-License-Identifier = "CC-BY-4.0"
+
+# ─────────────────────────────────────────────────────────────────────
+# Binary assets (cannot carry inline headers)
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = [
+  "**/*.png",
+  "**/*.jpg",
+  "**/*.jpeg",
+  "**/*.gif",
+  "**/*.svg",
+  "**/*.ico",
+  "**/*.pdf",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 European Space Agency (ESA)"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ─────────────────────────────────────────────────────────────────────
+# Sphinx build artefacts (generated; deployed with the documentation
+# site, not part of the source tree)
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = [
+  "docs/_build/**",
+  "docs/_static/css/**",
+  "docs/_static/js/**",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 European Space Agency (ESA)"
+SPDX-License-Identifier = "Apache-2.0"
+
+# ─────────────────────────────────────────────────────────────────────
+# Licence texts themselves are CC0
+# ─────────────────────────────────────────────────────────────────────
+[[annotations]]
+path = ["LICENSES/**"]
+precedence = "override"
+SPDX-FileCopyrightText = "Various"
+SPDX-License-Identifier = "CC0-1.0"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 European Space Agency (ESA)
SPDX-License-Identifier: Apache-2.0

Thanks for contributing to BIOMASS BPS. Before opening this PR, make sure a
tracking issue exists, opened with one of the five issue templates. The issue
captures the context (component, motivation, scientific justification). This
PR describes the change (what is in the diff).
-->

## Linked issue

<!--
The linked issue must already exist in the backlog and have been triaged.
A PR opened against a non-triaged or rejected issue will not be reviewed.
-->

Closes #20 

- [x] The linked issue is labelled `status:approved`, `good-first-issue` or `help-wanted`. 
Being open in the backlog is not enough on its own: only these three labels mean the scope has been triaged and approved for implementation.

## What this PR changes

<!--
Three to five bullets describing the diff in plain language.
Do not re-describe the problem, that lives in the linked issue.
-->

- Adds .github/CODEOWNERS to route PR review automatically by file path. The current routing is a placeholder pending input from maintainers (see Notes for reviewers).
- Adds .github/dependabot.yml to monitor Python dependencies (pyproject.toml per bps-* package), GitHub Actions versions, and Docker base images on a weekly grouped schedule. Reviewers are assigned via CODEOWNERS.
- Adds REUSE.toml and LICENSES/Apache-2.0.txt + LICENSES/MIT.txt to make the repository REUSE-compliant via bulk annotations covering all legacy files by category.

## Notes for reviewers @matteoaletti 

<!--
Optional. Anything reviewers should look at carefully: a non-obvious design
choice, a regression risk you mitigated, an area you would like a second
opinion on, a known limitation deferred to a follow-up issue.
Delete this section if there is nothing to flag.
-->

1. CODEOWNERS routing will needs your input.
The CODEOWNERS file currently routes almost every path to the primary maintainer as a placeholder, because I do not yet have the GitHub handles or team names for the Scientific Module Experts (SMEs) and area maintainers. Could you tell me who should own:

- bps-l1_* paths
- bps-l2* paths
- bps-stack_* paths
- docs/** and the wiki


2. REUSE compliance is delivered via the manifest, not inline headers.
REUSE.toml covers all existing legacy files by category. A follow-up issue will track the progressive migration of legacy files to inline SPDX headers. Every new file added from this PR onwards is expected to carry inline headers.

3. Three files marked as third-party with a provisional licence.
eop.xsd, sar.xsd, and bio-l1-vrt.xsd are declared as OGC / CC-BY-4.0 on a provisional basis. We should discuss with ESA and confirm the actual licence before merge.


## User-facing change

- [ ] This PR introduces a user-facing change (API, CLI, output format, performance, documentation).

If yes, write one short release-note sentence here (it will be picked up in `CHANGELOG.md`):


## Documentation

- [ ] This PR modifies the documentation (Sphinx site, README, wiki, ATBD, Science Guide).
- [X] This PR does not modify the documentation, and no documentation update is needed.
- [ ] This PR does not modify the documentation, but a documentation update is needed and tracked in issue #_____.

## Tier rationale

The CI computes the tier automatically from the diff against the base branch. You do not assign it, but stating your expectation helps reviewers spot a mismatch quickly.

| Tier | Triggers | Checks that run |
|---|---|---|
| **0** | Routine changes, no sensitive path touched | Baseline only |
| **1** | Locked paths, SME-owned paths, marker fail, Dependabot major | Baseline + Extended |
| **2** | `VERSION` promoted to `main`, designated heavy paths, manual `run_heavy` | Baseline + Extended + Heavy |

Full rules: [`.github/tier-policy.yml`](.github/tier-policy.yml). Background: [Contribution tiers in the contributor guide](../../wiki/CONTRIBUTING_PART1#contribution-tiers).

* Expected tier: 0 <!-- 0 / 1 / 2 -->
* Why: configuration-only files

## AI assistance disclosure

<!--
Following the practice established by NumPy, xarray and others, we ask
contributors to disclose AI assistance. This is informational, not gating.
-->

- [ ] No AI tools were used to prepare this PR.
- [X] AI tools were used. Tool(s):  &nbsp;<!-- e.g. Copilot, Claude, ChatGPT, Codex -->
      <br>What was generated (code, tests, documentation, commit messages): Commit messages / Comment
- [X] I have reviewed the generated content and take responsibility for it.

## Checklist

- [X] This PR closes exactly one tracking issue, linked above.
- [X] The scope of the diff matches the approved scope in the linked issue. No drift, no extras.
- [X] A breaking change is explicitly flagged in the release note sentence above (if applicable).
- [X] The reviewer assigned has the relevant domain knowledge for this change.
