### PR TITLE
L2 JIRA requests fixed and other minor fixes

### DIFF
--- a/bps-l2a_processor/bps/l2a_processor/commands.py
+++ b/bps-l2a_processor/bps/l2a_processor/commands.py
@@ -175,12 +175,17 @@ def run_l2a_processing(
             stack_products_list.append(stack_product_obj.read())
             acquisition_paths_selected.append(acquisition_path)
 
-            decoded_quality = StackQualityIndex.decode(stack_product_obj.stack_quality.overall_product_quality_index)
-            decoded_quality_string = [k.replace("_", " ") for k, v in decoded_quality.__dict__.items() if v is True]
-            if len(decoded_quality_string):
-                bps_logger.warning(
-                    f"Input L1c acquisition staQuality overallProductQualityIndex={stack_product_obj.stack_quality.overall_product_quality_index}: {decoded_quality_string[0]}"
-                )
+            sta_decoded_quality = StackQualityIndex.decode(
+                stack_product_obj.stack_quality.overall_product_quality_index
+            )
+            sta_decoded_quality_string = [
+                k.replace("_", " ") for k, v in vars(sta_decoded_quality).items() if v is True
+            ]
+            if len(sta_decoded_quality_string):
+                sta_quality_messages = ", ".join(sta_decoded_quality_string)
+                sta_message = f"Input L1c acquisition staQuality overall product quality index={stack_product_obj.stack_quality.overall_product_quality_index}: {sta_quality_messages}"
+                bps_logger.warning(f"{sta_message}")
+
             if stack_product_obj.stack_processing_parameters.skp_phase_correction_flag:
                 bps_logger.debug(f"SKP phase correction has been applied to input L1c acquisition {acquisition_path}")
                 if counter == 0 and aux_pp2_2a.general.apply_calibration_screen != CalibrationScreenType.NONE:

--- a/bps-l2b_fd_processor/bps/l2b_fd_processor/fd/fd_commands.py
+++ b/bps-l2b_fd_processor/bps/l2b_fd_processor/fd/fd_commands.py
@@ -239,21 +239,18 @@ class FDL2B:
 
         # Footprint mask for quick looks transparency
         footprint_masks_for_quicklooks = {}
+        fd_for_footprint = data_3d_mat_dict["fd"]
         if AVERAGING_FACTOR_QUICKLOOKS > 1:
-            fd_for_footprint = data_3d_mat_dict["fd"].squeeze()[
-                ::DECIMATION_FACTOR_QUICKLOOKS, ::DECIMATION_FACTOR_QUICKLOOKS
-            ]
-        else:
-            fd_for_footprint = data_3d_mat_dict["dh"].squeeze()
-        footprint_masks_for_quicklooks["data_mask"] = np.logical_not(np.isnan(fd_for_footprint))
+            fd_for_footprint = data_3d_mat_dict["fd"][::DECIMATION_FACTOR_QUICKLOOKS, ::DECIMATION_FACTOR_QUICKLOOKS]
+        footprint_masks_for_quicklooks["data_mask"] = np.logical_not(np.isnan(fd_for_footprint)).any(axis=-1)
 
         # Footprint mask for quick looks transparency
-        cfm_no_data_value_mask = data_3d_mat_dict["cfm"].squeeze() == INT_NODATA_VALUE
-        cfm_for_footprint = data_3d_mat_dict["cfm"].squeeze().astype(np.float32)
+        cfm_no_data_value_mask = data_3d_mat_dict["cfm"] == INT_NODATA_VALUE
+        cfm_for_footprint = data_3d_mat_dict["cfm"].astype(np.float32)
         cfm_for_footprint[cfm_no_data_value_mask] = np.nan
         if AVERAGING_FACTOR_QUICKLOOKS > 1:
             cfm_for_footprint = cfm_for_footprint[::DECIMATION_FACTOR_QUICKLOOKS, ::DECIMATION_FACTOR_QUICKLOOKS]
-        footprint_masks_for_quicklooks["cfm_mask"] = np.logical_not(np.isnan(cfm_for_footprint))
+        footprint_masks_for_quicklooks["cfm_mask"] = np.logical_not(np.isnan(cfm_for_footprint)).any(axis=-1)
 
         return (
             l2b_data_final_d,

--- a/bps-l2b_fd_processor/bps/l2b_fd_processor/fd/fd_commands.py
+++ b/bps-l2b_fd_processor/bps/l2b_fd_processor/fd/fd_commands.py
@@ -84,48 +84,53 @@ class FDL2B:
         global_coverage_id = None
         l2a_inputs_list = []
         basin_id_list = []
+        counter = 0
         for idx, l2a_product in enumerate(self.l2a_fd_products_list):
-            basin_id_list = basin_id_list + l2a_product.main_ads_product.basin_id_list
+            if self.job_order.processing_parameters.tile_id in l2a_product.main_ads_product.tile_id_list:
+                # Only the used L2A products (see dgg_tiling)
 
-            footprint = main_annotation_models_l2b_fd.FloatArrayWithUnits(
-                value=l2a_product.main_ads_input_information.footprint,
-                count=8,
-                units=common_types.UomType.DEG,
-            )
+                basin_id_list = basin_id_list + l2a_product.main_ads_product.basin_id_list
 
-            l1_inputs = common_annotation_models_l2.InputInformationL2AType(
-                product_type=common_annotation_models_l2.ProductType(
-                    l2a_product.main_ads_input_information.product_type
-                ),
-                overall_products_quality_index=l2a_product.main_ads_input_information.overall_products_quality_index,
-                nominal_stack=str(l2a_product.main_ads_input_information.nominal_stack).lower(),
-                polarisation_list=l2a_product.main_ads_input_information.polarisation_list,
-                projection=common_annotation_models_l2.ProjectionType(
-                    l2a_product.main_ads_input_information.projection
-                ),
-                footprint=footprint,
-                vertical_wavenumbers=l2a_product.main_ads_input_information.vertical_wavenumbers,
-                height_of_ambiguity=l2a_product.main_ads_input_information.height_of_ambiguity,
-                acquisition_list=l2a_product.main_ads_input_information.acquisition_list,
-            )
-
-            l2a_inputs_list.append(
-                common_annotation_models_l2.InputInformationL2BL3ListType.L2AInputs(
-                    l2a_product_folder_name=str(self.job_order.input_l2a_products[idx]),
-                    l2a_product_date=l2a_product.main_ads_product.start_time.isoformat(timespec="microseconds"),
-                    l1_inputs=l1_inputs,
-                    significance_level=l2a_product.main_ads_processing_parameters.significance_level,
+                footprint = main_annotation_models_l2b_fd.FloatArrayWithUnits(
+                    value=l2a_product.main_ads_input_information.footprint,
+                    count=8,
+                    units=common_types.UomType.DEG,
                 )
-            )
 
-            if idx == 0:
-                mission_phase_id = l2a_product.main_ads_product.mission_phase_id
-                global_coverage_id = l2a_product.main_ads_product.global_coverage_id
-            else:
-                if not mission_phase_id == l2a_product.main_ads_product.mission_phase_id:
-                    raise ValueError(
-                        "Input L2a products should be of the same phase: found some INT and some TOM phase L2a products."
+                l1_inputs = common_annotation_models_l2.InputInformationL2AType(
+                    product_type=common_annotation_models_l2.ProductType(
+                        l2a_product.main_ads_input_information.product_type
+                    ),
+                    overall_products_quality_index=l2a_product.main_ads_input_information.overall_products_quality_index,
+                    nominal_stack=str(l2a_product.main_ads_input_information.nominal_stack).lower(),
+                    polarisation_list=l2a_product.main_ads_input_information.polarisation_list,
+                    projection=common_annotation_models_l2.ProjectionType(
+                        l2a_product.main_ads_input_information.projection
+                    ),
+                    footprint=footprint,
+                    vertical_wavenumbers=l2a_product.main_ads_input_information.vertical_wavenumbers,
+                    height_of_ambiguity=l2a_product.main_ads_input_information.height_of_ambiguity,
+                    acquisition_list=l2a_product.main_ads_input_information.acquisition_list,
+                )
+
+                l2a_inputs_list.append(
+                    common_annotation_models_l2.InputInformationL2BL3ListType.L2AInputs(
+                        l2a_product_folder_name=str(self.job_order.input_l2a_products[idx]),
+                        l2a_product_date=l2a_product.main_ads_product.start_time.isoformat(timespec="microseconds"),
+                        l1_inputs=l1_inputs,
+                        significance_level=l2a_product.main_ads_processing_parameters.significance_level,
                     )
+                )
+
+                if counter == 0:
+                    mission_phase_id = l2a_product.main_ads_product.mission_phase_id
+                    global_coverage_id = l2a_product.main_ads_product.global_coverage_id
+                else:
+                    if not mission_phase_id == l2a_product.main_ads_product.mission_phase_id:
+                        raise ValueError(
+                            "Input L2a products should be of the same phase: found some INT and some TOM phase L2a products."
+                        )
+                counter += 1
 
         return (
             l2a_inputs_list,
@@ -231,11 +236,17 @@ class FDL2B:
             main_ads_input_information_l2b = None
             bps_logger.info("L2b FD processor: nothing to compute, exiting.")
 
-        start_time_l2a = self.l2a_fd_products_list[0].main_ads_product.start_time
-        stop_time_l2a = self.l2a_fd_products_list[0].main_ads_product.stop_time
+        start_time_l2a = None
+        stop_time_l2a = None
         for l2a_product in self.l2a_fd_products_list:
-            start_time_l2a = min(start_time_l2a, l2a_product.main_ads_product.start_time)
-            stop_time_l2a = max(stop_time_l2a, l2a_product.main_ads_product.stop_time)
+            if self.job_order.processing_parameters.tile_id in l2a_product.main_ads_product.tile_id_list:
+                # Only the used L2A products (see dgg_tiling)
+                if start_time_l2a is None:
+                    start_time_l2a = l2a_product.main_ads_product.start_time
+                    stop_time_l2a = l2a_product.main_ads_product.stop_time
+                else:
+                    start_time_l2a = min(start_time_l2a, l2a_product.main_ads_product.start_time)
+                    stop_time_l2a = max(stop_time_l2a, l2a_product.main_ads_product.stop_time)  # type: ignore
 
         # Footprint mask for quick looks transparency
         footprint_masks_for_quicklooks = {}

--- a/bps-l2b_fh_processor/bps/l2b_fh_processor/fh/fh_commands.py
+++ b/bps-l2b_fh_processor/bps/l2b_fh_processor/fh/fh_commands.py
@@ -93,47 +93,52 @@ class FHL2B:
         global_coverage_id = None
         l2a_inputs_list = []
         basin_id_list = []
+        counter = 0
         for idx, l2a_product in enumerate(self.l2a_fh_products_list):
-            basin_id_list = basin_id_list + l2a_product.main_ads_product.basin_id_list
+            if self.job_order.processing_parameters.tile_id in l2a_product.main_ads_product.tile_id_list:
+                # Only the used L2A products (see dgg_tiling)
 
-            footprint = main_annotation_models_l2b_fh.FloatArrayWithUnits(
-                value=l2a_product.main_ads_input_information.footprint,
-                count=8,
-                units=common_types.UomType.DEG,
-            )
+                basin_id_list = basin_id_list + l2a_product.main_ads_product.basin_id_list
 
-            l1_inputs = common_annotation_models_l2.InputInformationL2AType(
-                product_type=common_annotation_models_l2.ProductType(
-                    l2a_product.main_ads_input_information.product_type
-                ),
-                overall_products_quality_index=l2a_product.main_ads_input_information.overall_products_quality_index,
-                nominal_stack=str(l2a_product.main_ads_input_information.nominal_stack).lower(),
-                polarisation_list=l2a_product.main_ads_input_information.polarisation_list,
-                projection=common_annotation_models_l2.ProjectionType(
-                    l2a_product.main_ads_input_information.projection
-                ),
-                footprint=footprint,
-                vertical_wavenumbers=l2a_product.main_ads_input_information.vertical_wavenumbers,
-                height_of_ambiguity=l2a_product.main_ads_input_information.height_of_ambiguity,
-                acquisition_list=l2a_product.main_ads_input_information.acquisition_list,
-            )
-
-            l2a_inputs_list.append(
-                common_annotation_models_l2.InputInformationL2BL3ListType.L2AInputs(
-                    l2a_product_folder_name=str(self.job_order.input_l2a_products[idx]),
-                    l2a_product_date=l2a_product.main_ads_product.start_time.isoformat(timespec="microseconds"),
-                    l1_inputs=l1_inputs,
+                footprint = main_annotation_models_l2b_fh.FloatArrayWithUnits(
+                    value=l2a_product.main_ads_input_information.footprint,
+                    count=8,
+                    units=common_types.UomType.DEG,
                 )
-            )
 
-            if idx == 0:
-                mission_phase_id = l2a_product.main_ads_product.mission_phase_id
-                global_coverage_id = l2a_product.main_ads_product.global_coverage_id
-            else:
-                if not mission_phase_id == l2a_product.main_ads_product.mission_phase_id:
-                    raise ValueError(
-                        "Input L2a products should be of the same phase: found some INT and some TOM phase L2a products."
+                l1_inputs = common_annotation_models_l2.InputInformationL2AType(
+                    product_type=common_annotation_models_l2.ProductType(
+                        l2a_product.main_ads_input_information.product_type
+                    ),
+                    overall_products_quality_index=l2a_product.main_ads_input_information.overall_products_quality_index,
+                    nominal_stack=str(l2a_product.main_ads_input_information.nominal_stack).lower(),
+                    polarisation_list=l2a_product.main_ads_input_information.polarisation_list,
+                    projection=common_annotation_models_l2.ProjectionType(
+                        l2a_product.main_ads_input_information.projection
+                    ),
+                    footprint=footprint,
+                    vertical_wavenumbers=l2a_product.main_ads_input_information.vertical_wavenumbers,
+                    height_of_ambiguity=l2a_product.main_ads_input_information.height_of_ambiguity,
+                    acquisition_list=l2a_product.main_ads_input_information.acquisition_list,
+                )
+
+                l2a_inputs_list.append(
+                    common_annotation_models_l2.InputInformationL2BL3ListType.L2AInputs(
+                        l2a_product_folder_name=str(self.job_order.input_l2a_products[idx]),
+                        l2a_product_date=l2a_product.main_ads_product.start_time.isoformat(timespec="microseconds"),
+                        l1_inputs=l1_inputs,
                     )
+                )
+
+                if counter == 0:
+                    mission_phase_id = l2a_product.main_ads_product.mission_phase_id
+                    global_coverage_id = l2a_product.main_ads_product.global_coverage_id
+                else:
+                    if not mission_phase_id == l2a_product.main_ads_product.mission_phase_id:
+                        raise ValueError(
+                            "Input L2a products should be of the same phase: found some INT and some TOM phase L2a products."
+                        )
+                counter += 1
 
         return (
             l2a_inputs_list,
@@ -199,7 +204,9 @@ class FHL2B:
 
             data_footprint_list = []
             for l2a_product in self.l2a_fh_products_list:
-                data_footprint_list.append(np.array(l2a_product.main_ads_input_information.footprint))
+                if self.job_order.processing_parameters.tile_id in l2a_product.main_ads_product.tile_id_list:
+                    # Only the used L2A products (see dgg_tiling)
+                    data_footprint_list.append(np.array(l2a_product.main_ads_input_information.footprint))
 
             # Average
             (

--- a/bps-l2b_fh_processor/bps/l2b_fh_processor/fh/fh_commands.py
+++ b/bps-l2b_fh_processor/bps/l2b_fh_processor/fh/fh_commands.py
@@ -259,13 +259,10 @@ class FHL2B:
             stop_time_l2a = max(stop_time_l2a, l2a_product.main_ads_product.stop_time)
 
         # Footprint mask for quick looks transparency
+        fh_for_footprint = data_3d_mat_dict["fh"]
         if AVERAGING_FACTOR_QUICKLOOKS > 1:
-            fh_for_footprint = data_3d_mat_dict["fh"].squeeze()[
-                ::DECIMATION_FACTOR_QUICKLOOKS, ::DECIMATION_FACTOR_QUICKLOOKS
-            ]
-        else:
-            fh_for_footprint = data_3d_mat_dict["fh"].squeeze()
-        footprint_mask_for_quicklooks = np.logical_not(np.isnan(fh_for_footprint))
+            fh_for_footprint = data_3d_mat_dict["fh"][::DECIMATION_FACTOR_QUICKLOOKS, ::DECIMATION_FACTOR_QUICKLOOKS]
+        footprint_mask_for_quicklooks = np.logical_not(np.isnan(fh_for_footprint)).any(axis=-1)
 
         return (
             l2b_data_final_d,

--- a/bps-transcoder/bps/transcoder/sarproduct/biomass_l2bfdproduct_writer.py
+++ b/bps-transcoder/bps/transcoder/sarproduct/biomass_l2bfdproduct_writer.py
@@ -1008,106 +1008,106 @@ class BIOMASSL2bFDProductWriter:
         _type_
             _description_
         """
+        with np.errstate(divide="ignore", invalid="ignore"):  # FD may have all NaNs at first cycle
+            dirname = Path(self.product_structure.quicklook_files[0]).parent
+            if not dirname.exists():
+                dirname.mkdir(parents=True, exist_ok=True)
 
-        dirname = Path(self.product_structure.quicklook_files[0]).parent
-        if not dirname.exists():
-            dirname.mkdir(parents=True, exist_ok=True)
+            for key in self.product.measurement.data_dict.keys():
+                if key not in [
+                    "fd",
+                    "cfm",
+                    "probability_ofchange",
+                    "heat_map",
+                ]:
+                    continue
 
-        for key in self.product.measurement.data_dict.keys():
-            if key not in [
-                "fd",
-                "cfm",
-                "probability_ofchange",
-                "heat_map",
-            ]:
-                continue
+                imm_to_save = self.product.measurement.data_dict[key]
 
-            imm_to_save = self.product.measurement.data_dict[key]
-
-            # set no data values to zeros, for the quick look
-            name_to_search = "_" + key + "_ql"
-            if key in ["fd", "cfm"]:
-                imm_to_save[imm_to_save == INT_NODATA_VALUE] = 0
-            if key == "heat_map":
-                imm_to_save1 = self.product.measurement.data_dict[key]["heat_map_contributing"]
-                imm_to_save2 = self.product.measurement.data_dict[key]["heat_map_agreeing"]
-                imm_to_save1[imm_to_save1 == INT_NODATA_VALUE] = 0
-                imm_to_save2[imm_to_save2 == INT_NODATA_VALUE] = 0
-            if key == "probability_ofchange":
-                imm_to_save[imm_to_save == FLOAT_NODATA_VALUE] = 0.0
-                name_to_search = "_probability_ql"
-
-            # If required, multilook input data
-            if AVERAGING_FACTOR_QUICKLOOKS > 1:
-                boxcar = np.ones((AVERAGING_FACTOR_QUICKLOOKS, AVERAGING_FACTOR_QUICKLOOKS))
-
+                # set no data values to zeros, for the quick look
+                name_to_search = "_" + key + "_ql"
+                if key in ["fd", "cfm"]:
+                    imm_to_save[imm_to_save == INT_NODATA_VALUE] = 0
                 if key == "heat_map":
-                    imm_to_save1 = np.sqrt(
-                        convolve2d(imm_to_save1**2, boxcar, "same")
-                        / (AVERAGING_FACTOR_QUICKLOOKS * AVERAGING_FACTOR_QUICKLOOKS)
-                    )[::DECIMATION_FACTOR_QUICKLOOKS, ::DECIMATION_FACTOR_QUICKLOOKS]
+                    imm_to_save1 = self.product.measurement.data_dict[key]["heat_map_contributing"]
+                    imm_to_save2 = self.product.measurement.data_dict[key]["heat_map_agreeing"]
+                    imm_to_save1[imm_to_save1 == INT_NODATA_VALUE] = 0
+                    imm_to_save2[imm_to_save2 == INT_NODATA_VALUE] = 0
+                if key == "probability_ofchange":
+                    imm_to_save[imm_to_save == FLOAT_NODATA_VALUE] = 0.0
+                    name_to_search = "_probability_ql"
 
-                    imm_to_save2 = np.sqrt(
-                        convolve2d(imm_to_save2**2, boxcar, "same")
-                        / (AVERAGING_FACTOR_QUICKLOOKS * AVERAGING_FACTOR_QUICKLOOKS)
-                    )[::DECIMATION_FACTOR_QUICKLOOKS, ::DECIMATION_FACTOR_QUICKLOOKS]
-                else:
-                    imm_to_save = np.sqrt(
-                        convolve2d(imm_to_save**2, boxcar, "same")
-                        / (AVERAGING_FACTOR_QUICKLOOKS * AVERAGING_FACTOR_QUICKLOOKS)
-                    )[::DECIMATION_FACTOR_QUICKLOOKS, ::DECIMATION_FACTOR_QUICKLOOKS]
+                # If required, multilook input data
+                if AVERAGING_FACTOR_QUICKLOOKS > 1:
+                    boxcar = np.ones((AVERAGING_FACTOR_QUICKLOOKS, AVERAGING_FACTOR_QUICKLOOKS))
 
-            fname = None
-            for fname in self.product_structure.quicklook_files:
-                if name_to_search in fname:
-                    break
-            assert fname is not None
+                    if key == "heat_map":
+                        imm_to_save1 = np.sqrt(
+                            convolve2d(imm_to_save1**2, boxcar, "same")
+                            / (AVERAGING_FACTOR_QUICKLOOKS * AVERAGING_FACTOR_QUICKLOOKS)
+                        )[::DECIMATION_FACTOR_QUICKLOOKS, ::DECIMATION_FACTOR_QUICKLOOKS]
 
-            # Write quicklook file
-            if key == "heat_map":
-                full_fname = Path(fname)
-                file_name = full_fname.name
-                file_name1 = file_name[0:35] + "hmcontrib_ql.png"
-                full_fname1 = str(full_fname.parent.joinpath(file_name1))
-                file_name2 = file_name[0:35] + "hmagreeing_ql.png"
-                full_fname2 = str(full_fname.parent.joinpath(file_name2))
+                        imm_to_save2 = np.sqrt(
+                            convolve2d(imm_to_save2**2, boxcar, "same")
+                            / (AVERAGING_FACTOR_QUICKLOOKS * AVERAGING_FACTOR_QUICKLOOKS)
+                        )[::DECIMATION_FACTOR_QUICKLOOKS, ::DECIMATION_FACTOR_QUICKLOOKS]
+                    else:
+                        imm_to_save = np.sqrt(
+                            convolve2d(imm_to_save**2, boxcar, "same")
+                            / (AVERAGING_FACTOR_QUICKLOOKS * AVERAGING_FACTOR_QUICKLOOKS)
+                        )[::DECIMATION_FACTOR_QUICKLOOKS, ::DECIMATION_FACTOR_QUICKLOOKS]
 
-                # Scale float values to be integers in the [0:255] range
-                imm_to_save1 = (255.0 * imm_to_save1 / np.max(imm_to_save1)).astype(np.uint8)
-                imm_to_save2 = (255.0 * imm_to_save2 / np.max(imm_to_save2)).astype(np.uint8)
+                fname = None
+                for fname in self.product_structure.quicklook_files:
+                    if name_to_search in fname:
+                        break
+                assert fname is not None
 
-                # Convert from 2D GRAY image a 4D BGRA (replica of image in three RGB channels)
-                imm_bgra1 = cv2.cvtColor(imm_to_save1, cv2.COLOR_GRAY2BGRA)
-                # make transparent (alpha = 0) out of the footprint
-                alpha = np.where(self.footprint_masks_for_quicklooks["data_mask"], 255, 0).astype(np.uint8)
-                # Insert Alpha channel to the image BRGA
-                imm_bgra1[:, :, 3] = alpha
-                cv2.imwrite(fname, imm_bgra1)
+                # Write quicklook file
+                if key == "heat_map":
+                    full_fname = Path(fname)
+                    file_name = full_fname.name
+                    file_name1 = file_name[0:35] + "hmcontrib_ql.png"
+                    full_fname1 = str(full_fname.parent.joinpath(file_name1))
+                    file_name2 = file_name[0:35] + "hmagreeing_ql.png"
+                    full_fname2 = str(full_fname.parent.joinpath(file_name2))
 
-                # Convert from 2D GRAY image a 4D BGRA (replica of image in three RGB channels)
-                imm_bgra2 = cv2.cvtColor(imm_to_save2, cv2.COLOR_GRAY2BGRA)
-                # make transparent (alpha = 0) out of the footprint
-                alpha = np.where(self.footprint_masks_for_quicklooks["data_mask"], 255, 0).astype(np.uint8)
-                # Insert Alpha channel to the image BRGA
-                imm_bgra2[:, :, 3] = alpha
+                    # Scale float values to be integers in the [0:255] range
+                    imm_to_save1 = (255.0 * imm_to_save1 / np.max(imm_to_save1)).astype(np.uint8)
+                    imm_to_save2 = (255.0 * imm_to_save2 / np.max(imm_to_save2)).astype(np.uint8)
 
-                cv2.imwrite(full_fname1, imm_bgra1)
-                cv2.imwrite(full_fname2, imm_bgra1)
-
-            else:
-                # Scale float values to be integers in the [0:255] range
-                imm_to_save = (255.0 * imm_to_save / np.max(imm_to_save)).astype(np.uint8)
-
-                # Convert from 2D GRAY image a 4D BGRA (replica of image in three RGB channels)
-                imm_bgra = cv2.cvtColor(imm_to_save, cv2.COLOR_GRAY2BGRA)
-                # make transparent (alpha = 0) out of the footprint
-                if key == "cfm":
-                    alpha = np.where(self.footprint_masks_for_quicklooks["cfm_mask"], 255, 0).astype(np.uint8)
-                else:
+                    # Convert from 2D GRAY image a 4D BGRA (replica of image in three RGB channels)
+                    imm_bgra1 = cv2.cvtColor(imm_to_save1, cv2.COLOR_GRAY2BGRA)
+                    # make transparent (alpha = 0) out of the footprint
                     alpha = np.where(self.footprint_masks_for_quicklooks["data_mask"], 255, 0).astype(np.uint8)
-                # Insert Alpha channel to the image BRGA
-                imm_bgra[:, :, 3] = alpha
-                cv2.imwrite(fname, imm_bgra)
+                    # Insert Alpha channel to the image BRGA
+                    imm_bgra1[:, :, 3] = alpha
+                    cv2.imwrite(fname, imm_bgra1)
+
+                    # Convert from 2D GRAY image a 4D BGRA (replica of image in three RGB channels)
+                    imm_bgra2 = cv2.cvtColor(imm_to_save2, cv2.COLOR_GRAY2BGRA)
+                    # make transparent (alpha = 0) out of the footprint
+                    alpha = np.where(self.footprint_masks_for_quicklooks["data_mask"], 255, 0).astype(np.uint8)
+                    # Insert Alpha channel to the image BRGA
+                    imm_bgra2[:, :, 3] = alpha
+
+                    cv2.imwrite(full_fname1, imm_bgra1)
+                    cv2.imwrite(full_fname2, imm_bgra1)
+
+                else:
+                    # Scale float values to be integers in the [0:255] range
+                    imm_to_save = (255.0 * imm_to_save / np.max(imm_to_save)).astype(np.uint8)
+
+                    # Convert from 2D GRAY image a 4D BGRA (replica of image in three RGB channels)
+                    imm_bgra = cv2.cvtColor(imm_to_save, cv2.COLOR_GRAY2BGRA)
+                    # make transparent (alpha = 0) out of the footprint
+                    if key == "cfm":
+                        alpha = np.where(self.footprint_masks_for_quicklooks["cfm_mask"], 255, 0).astype(np.uint8)
+                    else:
+                        alpha = np.where(self.footprint_masks_for_quicklooks["data_mask"], 255, 0).astype(np.uint8)
+                    # Insert Alpha channel to the image BRGA
+                    imm_bgra[:, :, 3] = alpha
+                    cv2.imwrite(fname, imm_bgra)
 
     def _write_overlay_files(self):
         # NE, SE, SW, NW

--- a/bps-transcoder/bps/transcoder/utils/dgg_utils.py
+++ b/bps-transcoder/bps/transcoder/utils/dgg_utils.py
@@ -46,7 +46,7 @@ def dgg_search_tiles(latlon_coverage: list[float], create_tiles_dict: bool | Non
     tile_extent_lonlat_dict = {}  # list of tile degrees extension in lat / lon for each tile [tile extent lon deg, tile extent lat deg]
 
     # whole Copernicus latitude vector
-    latitude_vector = np.arange(-70, 70, tile_extent_lat) + pixel_spacing_lat / 2
+    latitude_vector = np.arange(-90, 90, tile_extent_lat) + pixel_spacing_lat / 2
 
     # Copernicus longitude pixel spacing varies depending on latitude sector
     pixel_spacing_lon_list = np.zeros(latitude_vector.shape).astype(np.float64)
@@ -55,8 +55,10 @@ def dgg_search_tiles(latlon_coverage: list[float], create_tiles_dict: bool | Non
     pixel_spacing_lon_list[np.logical_and(latitude_vector >= -50, latitude_vector < 50)] = 3 / 3600
     pixel_spacing_lon_list[np.logical_and(latitude_vector >= 50, latitude_vector < 60)] = 4.5 / 3600
     pixel_spacing_lon_list[np.logical_and(latitude_vector >= 60, latitude_vector < 70)] = 6 / 3600
+    pixel_spacing_lon_list[latitude_vector >= 70] = 6 / 3600
+    pixel_spacing_lon_list[latitude_vector <= -70] = 6 / 3600
 
-    lat_tiles_name = ["S{:02d}".format(70 - lat) for lat in range(0, 70, tile_extent_lat)] + [
+    lat_tiles_name = ["S{:02d}".format(90 - lat) for lat in range(0, 90, tile_extent_lat)] + [
         "N{:02d}".format(lat) for lat in range(0, 89, tile_extent_lat)
     ]
 


### PR DESCRIPTION
Solving Jira tickets:

- BPS-941 (bps l2b fd, fh, bug fix: allow more than one l2a in input, fixed)
- BPS-945 (bps l2a: allow l2a to process tiles over +70 degrees of latitude (and below -70))
- BPS-948 (bps l2a, improved overall product quality index warning message)

- Other minor fixe in l2b annotations (bps l2b fd, fh: solved annotation issue when some input l2a products are removed due to not covering the l2b tile_id)
- useless warnings suppression (bps l2b fd: suppress "divide" and "invalid" warnings during quick look writing (happening with fd first cycle products))


