### PR TITLE
bps l1 processor, fixed wrong mapping of ionospheric calibration configuration flag

### DIFF
--- a/bps-l1_core_processor/bps/l1_core_processor/translate.py
+++ b/bps-l1_core_processor/bps/l1_core_processor/translate.py
@@ -671,7 +671,7 @@ def translate_ionospheric_calibration_conf_to_model(
     return are_conf.IonosphericCalibrationConfType(
         beam=conf.swath,
         perform_defocusing_on_ionospheric_height=int(conf.perform_defocusing_on_ionospheric_height),
-        perform_faraday_rotation_correction=int(conf.perform_defocusing_on_ionospheric_height),
+        perform_faraday_rotation_correction=int(conf.perform_faraday_rotation_correction),
         perform_phase_screen_correction=int(conf.perform_phase_screen_correction),
         perform_group_delay_correction=int(conf.perform_group_delay_correction),
         ionospheric_height_estimation_method=are_conf.IonosphericCalibrationConfTypeIonosphericHeightEstimationMethod(


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 European Space Agency (ESA)
SPDX-License-Identifier: Apache-2.0

Thanks for contributing to BIOMASS BPS. Before opening this PR, make sure a
tracking issue exists, opened with one of the five issue templates. The issue
captures the context (component, motivation, scientific justification). This
PR describes the change (what is in the diff).
-->

## Linked issue

<!--
The linked issue must already exist in the backlog and have been triaged.
A PR opened against a non-triaged or rejected issue will not be reviewed.
-->

Closes #

- [ ] The linked issue is labelled `status:approved`, `good-first-issue` or `help-wanted`. 
Being open in the backlog is not enough on its own: only these three labels mean the scope has been triaged and approved for implementation.

## What this PR changes

<!--
Three to five bullets describing the diff in plain language.
Do not re-describe the problem, that lives in the linked issue.
-->

* An AUX_PP1 flag is wrongly mapped and used inside L1 processing. This PR fixes this issue

## Notes for reviewers

<!--
Optional. Anything reviewers should look at carefully: a non-obvious design
choice, a regression risk you mitigated, an area you would like a second
opinion on, a known limitation deferred to a follow-up issue.
Delete this section if there is nothing to flag.
-->

## User-facing change

- [ ] This PR introduces a user-facing change (API, CLI, output format, performance, documentation).

If yes, write one short release-note sentence here (it will be picked up in `CHANGELOG.md`):


## Documentation

- [ ] This PR modifies the documentation (Sphinx site, README, wiki, ATBD, Science Guide).
- [x] This PR does not modify the documentation, and no documentation update is needed.
- [ ] This PR does not modify the documentation, but a documentation update is needed and tracked in issue #_____.

## Tier rationale

* Expected tier: 0
* Why: Minor fix

## AI assistance disclosure

<!--
Following the practice established by NumPy, xarray and others, we ask
contributors to disclose AI assistance. This is informational, not gating.
-->

- [x] No AI tools were used to prepare this PR.
- [ ] AI tools were used. Tool(s):  &nbsp;<!-- e.g. Copilot, Claude, ChatGPT, Codex -->
      <br>What was generated (code, tests, documentation, commit messages):
      <br>I have reviewed the generated content and take responsibility for it.

## Checklist

- [x] This PR closes exactly one tracking issue, linked above.
- [x] The scope of the diff matches the approved scope in the linked issue. No drift, no extras.
- [ ] A breaking change is explicitly flagged in the release note sentence above (if applicable).
- [x] The reviewer assigned has the relevant domain knowledge for this change.
