### PR TITLE
bps l1 processor, fixed invalid computation of in/out-of-band power ratio values

### DIFF
--- a/bps-l1_processor/bps/l1_processor/core/iobpr_utils.py
+++ b/bps-l1_processor/bps/l1_processor/core/iobpr_utils.py
@@ -107,7 +107,9 @@ def analyse_raw_product(
             data_spectrum = abs_sq_fft.mean(axis=0) / normalization_factor
 
             # Resample range spectrum
-            data_spectrum = np.bincount(data_spectrum_axis_id, weights=data_spectrum, minlength=n_bins) / bin_count
+            with np.errstate(divide="ignore", invalid="ignore"):
+                data_spectrum = np.bincount(data_spectrum_axis_id, weights=data_spectrum, minlength=n_bins) / bin_count
+                data_spectrum[~np.isfinite(data_spectrum)] = 0
 
             # Equalize range spectrum
             filter_spectrum = filter_spectrum_dict[swath_info.polarization.value]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 European Space Agency (ESA)
SPDX-License-Identifier: Apache-2.0

Thanks for contributing to BIOMASS BPS. Before opening this PR, make sure a
tracking issue exists, opened with one of the five issue templates. The issue
captures the context (component, motivation, scientific justification). This
PR describes the change (what is in the diff).
-->

## Linked issue

<!--
The linked issue must already exist in the backlog and have been triaged.
A PR opened against a non-triaged or rejected issue will not be reviewed.
-->

Closes #

- [ ] The linked issue is labelled `status:approved`, `good-first-issue` or `help-wanted`. 
Being open in the backlog is not enough on its own: only these three labels mean the scope has been triaged and approved for implementation.

## What this PR changes

<!--
Three to five bullets describing the diff in plain language.
Do not re-describe the problem, that lives in the linked issue.
-->

* When computing in/out-of-band power ratio a 0/0 computation was occurring, resulting in nan annotations in L1 product. This PR fixes this issue

## Notes for reviewers

<!--
Optional. Anything reviewers should look at carefully: a non-obvious design
choice, a regression risk you mitigated, an area you would like a second
opinion on, a known limitation deferred to a follow-up issue.
Delete this section if there is nothing to flag.
-->

## User-facing change

- [ ] This PR introduces a user-facing change (API, CLI, output format, performance, documentation).

If yes, write one short release-note sentence here (it will be picked up in `CHANGELOG.md`):


## Documentation

- [ ] This PR modifies the documentation (Sphinx site, README, wiki, ATBD, Science Guide).
- [x] This PR does not modify the documentation, and no documentation update is needed.
- [ ] This PR does not modify the documentation, but a documentation update is needed and tracked in issue #_____.

## Tier rationale

* Expected tier: 0
* Why: Minor fix

## AI assistance disclosure

<!--
Following the practice established by NumPy, xarray and others, we ask
contributors to disclose AI assistance. This is informational, not gating.
-->

- [x] No AI tools were used to prepare this PR.
- [ ] AI tools were used. Tool(s):  &nbsp;<!-- e.g. Copilot, Claude, ChatGPT, Codex -->
      <br>What was generated (code, tests, documentation, commit messages):
      <br>I have reviewed the generated content and take responsibility for it.

## Checklist

- [x] This PR closes exactly one tracking issue, linked above.
- [x] The scope of the diff matches the approved scope in the linked issue. No drift, no extras.
- [ ] A breaking change is explicitly flagged in the release note sentence above (if applicable).
- [x] The reviewer assigned has the relevant domain knowledge for this change.
