### PR TITLE
docs: mark First Developer Meeting (2026-06-30) as held

### DIFF
--- a/docs/presentations/2026-06-30-first-dev-meeting/meeting.yaml
+++ b/docs/presentations/2026-06-30-first-dev-meeting/meeting.yaml
@@ -1,4 +1,4 @@
 # Session status shown on docs pages (meetings + developer-meeting).
-# Change only `status` — allowed values:
+# Change only  + 'status' +  - allowed values:
 #   planned | held | cancelled
-status: planned
+status: held


### PR DESCRIPTION
Closes #44

Changed status: planned to status: held in docs/presentations/2026-06-30-first-dev-meeting/meeting.yaml on the docs/sphinx-site-migration branch.