### PR TITLE
fix(docs): correct typo 'runnin' → 'running' in README install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Both installation and usage procedures make use of the open-source package manag
     conda install biomass-bps::bps-l2b_agb_processor      # only for BPS L2B AGB Processor
     ```
 
-3. Check proper installation runnin help command:
+3. Check proper installation running help command:
 
     ```bash
     bps_l1_processor --help


### PR DESCRIPTION
Fixes a small typo in the Getting Started install section of README.md where 'runnin' should be 'running'. Closes #47.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._