### PR TITLE
l2: setting number of threads, as indicated in job order

### DIFF
--- a/bps-l2a_processor/bps/l2a_processor/commands.py
+++ b/bps-l2a_processor/bps/l2a_processor/commands.py
@@ -19,6 +19,7 @@ from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 
+import numba as nb
 import numpy as np
 from bps.common import bps_logger, retrieve_aux_product_data_single_content
 from bps.common.fnf_utils import read_fnf_mask, retrieve_fnf_content
@@ -94,6 +95,9 @@ def run_l2a_processing(
 
     # Input parsing: joborder
     job_order = parse_l2a_job_order(job_order_file.read_text())
+
+    # setting number of threads
+    nb.set_num_threads(job_order.device_resources.num_threads)
 
     # Relative paths in the joborder are intended as relative to the directory where the JobOrder is
     job_order_dir = job_order_file.parent

--- a/bps-l2b_agb_processor/bps/l2b_agb_processor/commands.py
+++ b/bps-l2b_agb_processor/bps/l2b_agb_processor/commands.py
@@ -17,6 +17,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 from pathlib import Path
 
+import numba as nb
 import numpy as np
 from bps.common import (
     bps_logger,
@@ -76,6 +77,9 @@ def run_l2b_agb_processing(
 
     # Input parsing: joborder
     job_order = parse_l2b_job_order(job_order_file.read_text())
+
+    # setting number of threads
+    nb.set_num_threads(job_order.device_resources.num_threads)
 
     # Relative paths in the joborder are intended as relative to the directory where the JobOrder is
     job_order_dir = job_order_file.parent

--- a/bps-l2b_fd_processor/bps/l2b_fd_processor/commands.py
+++ b/bps-l2b_fd_processor/bps/l2b_fd_processor/commands.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 
+import numba as nb
 import numpy as np
 from bps.common import bps_logger, retrieve_aux_product_data_single_content
 from bps.common.translate_job_order import get_bps_logger_level
@@ -51,6 +52,9 @@ def run_l2b_fd_processing(
 
     # Input parsing: joborder
     job_order = parse_l2b_job_order(job_order_file.read_text())
+
+    # setting number of threads
+    nb.set_num_threads(job_order.device_resources.num_threads)
 
     # Relative paths in the joborder are intended as relative to the directory where the JobOrder is
     job_order_dir = job_order_file.parent

--- a/bps-l2b_fh_processor/bps/l2b_fh_processor/commands.py
+++ b/bps-l2b_fh_processor/bps/l2b_fh_processor/commands.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 
+import numba as nb
 import numpy as np
 from bps.common import bps_logger, retrieve_aux_product_data_single_content
 from bps.common.translate_job_order import get_bps_logger_level
@@ -54,6 +55,9 @@ def run_l2b_fh_processing(
 
     # Input parsing: joborder
     job_order = parse_l2b_job_order(job_order_file.read_text())
+
+    # setting number of threads
+    nb.set_num_threads(job_order.device_resources.num_threads)
 
     # Relative paths in the joborder are intended as relative to the directory where the JobOrder is
     job_order_dir = job_order_file.parent


### PR DESCRIPTION
Max number of threads (as indicated in job order) is now set directly inside each of the l2 processors main "commands" functions.