### PR TITLE
Fix azimuth ALE measurements spread in PARC IRF analyses

### DIFF
--- a/bps-l1_processor/bps/l1_processor/folder_layout.py
+++ b/bps-l1_processor/bps/l1_processor/folder_layout.py
@@ -81,7 +81,9 @@ class FolderLayout:
                 parc_folder.joinpath(L1_CORE_PROC_OUTPUT_FOLDER)
             )
             parc_core_processor_files[scattering_response] = L1CoreProcessorInterfaceFiles.from_base_dir(parc_folder)
-            parc_core_additional_inputs[scattering_response] = L1ParcCoreAdditionalInputFiles.from_base_dir(parc_folder)
+            parc_core_additional_inputs[scattering_response] = L1ParcCoreAdditionalInputFiles.from_base_dir(
+                base_dir.joinpath(L1_CORE_PROC_OUTPUT_FOLDER)
+            )
 
         return cls(
             bps_logger_file,

--- a/bps-l1_processor/bps/l1_processor/parc/parc_processing_utils.py
+++ b/bps-l1_processor/bps/l1_processor/parc/parc_processing_utils.py
@@ -287,8 +287,10 @@ def update_aux_pp1_for_parc_processing(
     """
 
     for swath in STRIPMAP_SWATHS:
-        aux_pp1.azimuth_compression.parameters[swath].time_bias += parc_delays.azimuth_delay
         aux_pp1.range_compression.parameters[swath].time_bias += parc_delays.range_delay
+        aux_pp1.azimuth_compression.parameters[swath].time_bias += (
+            parc_delays.azimuth_delay - aux_pp1.range_compression.parameters[swath].time_bias
+        )
 
     aux_pp1.azimuth_compression.block_lines = (
         aux_pp1.azimuth_compression.block_overlap_lines

--- a/bps-l1_processor/bps/l1_processor/parc/parc_processing_utils.py
+++ b/bps-l1_processor/bps/l1_processor/parc/parc_processing_utils.py
@@ -10,11 +10,10 @@ PARC processing utils
 ---------
 """
 
-import shutil
 from pathlib import Path
 
 from arepytools.geometry.generalsarorbit import create_general_sar_orbit
-from arepytools.io import create_product_folder, iter_channels, open_product_folder, read_metadata, write_metadata
+from arepytools.io import open_product_folder, read_metadata
 from arepytools.io.metadata import Pulse
 from arepytools.timing.precisedatetime import PreciseDateTime
 from bps.common import bps_logger
@@ -297,34 +296,3 @@ def update_aux_pp1_for_parc_processing(
     ) + aux_pp1.general.parc_roi_lines // 2
 
     return aux_pp1
-
-
-def apply_delay_to_product(input_product: Path, parc_delays: Delays, delayed_product: Path):
-    """Apply delay directly to raster info"""
-
-    input_pf = open_product_folder(input_product)
-    output_pf = create_product_folder(delayed_product, overwrite_ok=True)
-
-    for channel_index, channel_metadata in iter_channels(input_pf):
-        input_raster_file = input_pf.get_channel_data(channel_index)
-        output_raster_file = output_pf.get_channel_data(channel_index)
-        output_metadata_file = output_pf.get_channel_metadata(channel_index)
-
-        shutil.copy2(input_raster_file, output_raster_file)
-
-        raster_info = channel_metadata.get_raster_info()
-        raster_info.file_name = output_raster_file.name
-        raster_info.set_lines_axis(
-            raster_info.lines_start - parc_delays.azimuth_delay,
-            raster_info.lines_start_unit,
-            raster_info.lines_step,
-            raster_info.lines_step_unit,
-        )
-        raster_info.set_samples_axis(
-            raster_info.samples_start - parc_delays.range_delay,
-            raster_info.samples_start_unit,
-            raster_info.samples_step,
-            raster_info.samples_step_unit,
-        )
-
-        write_metadata(channel_metadata, output_metadata_file)

--- a/bps-l1_processor/bps/l1_processor/parc/run.py
+++ b/bps-l1_processor/bps/l1_processor/parc/run.py
@@ -35,7 +35,6 @@ from bps.l1_processor.intermediate_footprint import (
 from bps.l1_processor.parc.parc_processing_info import Delays, Window
 from bps.l1_processor.parc.parc_processing_utils import (
     ScatteringResponse,
-    apply_delay_to_product,
     update_aux_pp1_for_parc_processing,
     update_job_order_for_parc_processing,
 )
@@ -238,26 +237,24 @@ def parc_processing_contex(
     parc_job_order = update_job_order_for_parc_processing(deepcopy(job_order), parc_processing_roi)
     parc_aux_pp1 = update_aux_pp1_for_parc_processing(deepcopy(aux_pp1), parc_delays)
 
-    # Ionospheric height model file is taken from the main run
+    # Ionospheric height model file, Faraday Rotation and Phase Screen products are taken from the main run
     parc_core_outputs.directory.mkdir(parents=True, exist_ok=True)
+
     if layout.core_processor_outputs.ionospheric_height_model_file.exists():
         shutil.copy(
             layout.core_processor_outputs.ionospheric_height_model_file,
             parc_core_outputs.ionospheric_height_model_file,
-        )
+        )  # file is copied to avoid deletion when removing parc_core_outputs
 
-    # Apply delay also to intermediate outputs from main run
     faraday_rotation_product = layout.core_processor_outputs.output_products.get(IntermediateProductID.FR, None)
     if faraday_rotation_product and faraday_rotation_product.path.exists():
-        apply_delay_to_product(
-            faraday_rotation_product.path, parc_delays, parc_core_additional_inputs.faraday_rotation_product
-        )
+        parc_core_additional_inputs.faraday_rotation_product = faraday_rotation_product.path
 
     phase_screen_product = layout.core_processor_outputs.output_products.get(
         IntermediateProductID.PHASE_SCREEN_BB, None
     )
     if phase_screen_product and phase_screen_product.path.exists():
-        apply_delay_to_product(phase_screen_product.path, parc_delays, parc_core_additional_inputs.phase_screen_product)
+        parc_core_additional_inputs.phase_screen_product = phase_screen_product.path
 
     yield parc_job_order, parc_aux_pp1, parc_core_files, parc_core_outputs, parc_core_additional_inputs
 
@@ -270,9 +267,6 @@ def parc_processing_contex(
 
         bps_logger.debug("Removing input L1 PARC core processor files")
         parc_core_files.delete()
-
-        bps_logger.debug("Removing input L1 PARC core additional inputs")
-        parc_core_additional_inputs.delete()
 
         # Remove the entire parc directory if empty
         if len(list(parc_core_files.directory.iterdir())) == 0:

--- a/bps-l1_processor/bps/l1_processor/settings/l1_intermediates.py
+++ b/bps-l1_processor/bps/l1_processor/settings/l1_intermediates.py
@@ -361,8 +361,8 @@ class L1ParcCoreAdditionalInputFiles:
     def from_base_dir(cls, base_dir: Path) -> L1ParcCoreAdditionalInputFiles:
         """Setup class from base directory"""
         return cls(
-            faraday_rotation_product=base_dir.joinpath("Input" + names.IntermediateProductID.FR.to_name()),
-            phase_screen_product=base_dir.joinpath("Input" + names.IntermediateProductID.PHASE_SCREEN_BB.to_name()),
+            faraday_rotation_product=base_dir.joinpath(names.IntermediateProductID.FR.to_name()),
+            phase_screen_product=base_dir.joinpath(names.IntermediateProductID.PHASE_SCREEN_BB.to_name()),
         )
 
     def delete(self):


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 European Space Agency (ESA)
SPDX-License-Identifier: Apache-2.0

Thanks for contributing to BIOMASS BPS. Before opening this PR, make sure a
tracking issue exists, opened with one of the five issue templates. The issue
captures the context (component, motivation, scientific justification). This
PR describes the change (what is in the diff).
-->

## Linked issue

<!--
The linked issue must already exist in the backlog and have been triaged.
A PR opened against a non-triaged or rejected issue will not be reviewed.
-->

Closes #

- [ ] The linked issue is labelled `status:approved`, `good-first-issue` or `help-wanted`. 
Being open in the backlog is not enough on its own: only these three labels mean the scope has been triaged and approved for implementation.

## What this PR changes

<!--
Three to five bullets describing the diff in plain language.
Do not re-describe the problem, that lives in the linked issue.
-->

* Fix BPS-930: L1_P: Wrong selection of FR and Phase Screen ROI for PARC processing

## Notes for reviewers

<!--
Optional. Anything reviewers should look at carefully: a non-obvious design
choice, a regression risk you mitigated, an area you would like a second
opinion on, a known limitation deferred to a follow-up issue.
Delete this section if there is nothing to flag.
-->

## User-facing change

- [ ] This PR introduces a user-facing change (API, CLI, output format, performance, documentation).

If yes, write one short release-note sentence here (it will be picked up in `CHANGELOG.md`):


## Documentation

- [ ] This PR modifies the documentation (Sphinx site, README, wiki, ATBD, Science Guide).
- [x] This PR does not modify the documentation, and no documentation update is needed.
- [ ] This PR does not modify the documentation, but a documentation update is needed and tracked in issue #_____.

## Tier rationale

The CI computes the tier automatically from the diff against the base branch. You do not assign it, but stating your expectation helps reviewers spot a mismatch quickly.

| Tier | Triggers | Checks that run |
|---|---|---|
| **0** | Routine changes, no sensitive path touched | Baseline only |
| **1** | Locked paths, SME-owned paths, marker fail, Dependabot major | Baseline + Extended |
| **2** | `VERSION` promoted to `main`, designated heavy paths, manual `run_heavy` | Baseline + Extended + Heavy |

Full rules: [`.github/tier-policy.yml`](.github/tier-policy.yml). Background: [Contribution tiers in the contributor guide](../../wiki/CONTRIBUTING_PART1#contribution-tiers).

* Expected tier: 0
* Why: Minor fix

## AI assistance disclosure

<!--
Following the practice established by NumPy, xarray and others, we ask
contributors to disclose AI assistance. This is informational, not gating.
-->

- [x] No AI tools were used to prepare this PR.
- [ ] AI tools were used. Tool(s):  &nbsp;<!-- e.g. Copilot, Claude, ChatGPT, Codex -->
      <br>What was generated (code, tests, documentation, commit messages):
      <br>I have reviewed the generated content and take responsibility for it.

## Checklist

- [x] This PR closes exactly one tracking issue, linked above.
- [x] The scope of the diff matches the approved scope in the linked issue. No drift, no extras.
- [ ] A breaking change is explicitly flagged in the release note sentence above (if applicable).
- [x] The reviewer assigned has the relevant domain knowledge for this change.
